### PR TITLE
Set minimal compiler version to 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 readme = "README.md"
 keywords = ["clipboard"]
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.63.0"
 
 [dependencies]
 image = "0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 readme = "README.md"
 keywords = ["clipboard"]
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.70.0"
 
 [dependencies]
 image = "0.24"


### PR DESCRIPTION
Distributions are conservative when it comes to build dependencies. Tested with:

```sh
rustup install 1.70.0
rustup override set 1.70.0
```