### PR TITLE
MSRV needs to be 1.67

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 readme = "README.md"
 keywords = ["clipboard"]
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.67.0"
 
 [dependencies]
 image = "0.25.2"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest version](https://img.shields.io/crates/v/clipboard-rs?color=mediumvioletred)](https://crates.io/crates/clipboard-rs)
 [![Documentation](https://docs.rs/clipboard-rs/badge.svg)](https://docs.rs/clipboard-rs)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/ChurchTao/clipboard-rs/test.yml)
-![MSRV](https://img.shields.io/badge/rustc-1.63+-blue.svg)
+![MSRV](https://img.shields.io/badge/rustc-1.67+-blue.svg)
 ![GitHub License](https://img.shields.io/github/license/ChurchTao/clipboard-rs)
 
 clipboard-rs is a cross-platform library written in Rust for getting and setting the system-level clipboard content. It supports Linux, Windows, and MacOS.


### PR DESCRIPTION
`image` has an MSRV of 1.67 in the 0.25 series (so far).

A dependency of `image` has a higher MSRV so this still won't compile with 1.67 without another change to use `image` without `default-features`.