### PR TITLE
Convergence  crate `image`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2 (2024-11-19) [released]
+
+- Convergence dep: `image` to `jpeg/png/tiff/bmp` [pr#54](https://github.com/ChurchTao/clipboard-rs/pull/54)
+
 ## v0.2.1 (2024-08-26) [released]
 
 ### zh:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clipboard-rs"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["ChurchTao <swkzymlyy@gmail.com>"]
 description = "Cross-platform clipboard API (text | image | rich text | html | files | monitoring changes) | 跨平台剪贴板 API(文本|图片|富文本|html|文件|监听变化) Windows,MacOS,Linux"
 repository = "https://github.com/ChurchTao/clipboard-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,18 @@ edition = "2021"
 rust-version = "1.67.0"
 
 [dependencies]
-image = { version = "0.25.4", default-features = false, features = ["png"] }
+image = { version = "0.25.4", default-features = false, features = [
+    "png",
+    "jpeg",
+] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 clipboard-win = { version = "5.4.0", features = ["monitor"] }
-image = { version = "0.25.4", default-features = false, features = ["bmp", "png"] }
+image = { version = "0.25.4", default-features = false, features = [
+    "bmp",
+    "png",
+    "jpeg",
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # cocoa = "0.26.0"
@@ -30,6 +37,11 @@ objc2-app-kit = { version = "0.2.2", features = [
     "NSPasteboard",
     "NSPasteboardItem",
     "NSImage",
+] }
+image = { version = "0.25.4", default-features = false, features = [
+    "tiff",
+    "png",
+    "jpeg",
 ] }
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the following content to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-clipboard-rs = "0.2.1"
+clipboard-rs = "0.2.2"
 ```
 
 ## [CHANGELOG](CHANGELOG.md)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -23,7 +23,7 @@ clipboard-rs 是一个用 Rust 语言编写的跨平台库，用于获取和设�
 
 ```toml
 [dependencies]
-clipboard-rs = "0.2.1"
+clipboard-rs = "0.2.2"
 ```
 
 ## [更新日志](CHANGELOG.md)


### PR DESCRIPTION
@waywardmonkeys 
> https://github.com/ChurchTao/clipboard-rs/pull/53

I understand what you mean. The reason I import all of them is that the clipboard does not only have png format images, for example, macOS also has TIFF, and Windows also has bmp or jpeg. And this is only when reading. When writing, I only want to write a jpeg format image. Users can use RustImage::from_bytes or RustImage::from_path to get the image object. So if I only import png, will it cause users to be unable to read the image?