### PR TITLE
Bump version to 0.3.0 and update error formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.0 (2025-07-01) [released]
+
+- Add: Support iOS, but only for test, not for production.
+- Fix: Merge [pr#62](https://github.com/ChurchTao/clipboard-rs/pull/62)
+
 ## v0.2.4 (2025-02-07) [released]
 
 - Fix: [pr#56](https://github.com/ChurchTao/clipboard-rs/pull/56)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clipboard-rs"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["ChurchTao <swkzymlyy@gmail.com>"]
 description = "Cross-platform clipboard API (text | image | rich text | html | files | monitoring changes) | 跨平台剪贴板 API(文本|图片|富文本|html|文件|监听变化) Windows,MacOS,Linux"
 repository = "https://github.com/ChurchTao/clipboard-rs"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add the following content to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-clipboard-rs = "0.2.4"
+clipboard-rs = "0.3.0"
 ```
 
 ## [CHANGELOG](CHANGELOG.md)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -37,7 +37,7 @@ clipboard-rs 是一个用 Rust 语言编写的跨平台库，用于获取和设�
 
 ```toml
 [dependencies]
-clipboard-rs = "0.2.4"
+clipboard-rs = "0.3.0"
 ```
 
 ## [更新日志](CHANGELOG.md)

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -318,7 +318,7 @@ impl ClipboardContext {
 		thread::spawn(move || {
 			let res = process_server_req(&ctx_clone);
 			if let Err(e) = res {
-				println!("process_server_req error: {:?}", e);
+				println!("process_server_req error: {e:?}");
 			}
 		});
 
@@ -393,7 +393,7 @@ fn process_server_req(context: &InnerContext) -> Result<()> {
 			.server_for_write
 			.conn
 			.wait_for_event()
-			.map_err(|e| format!("wait_for_event error: {:?}", e))?
+			.map_err(|e| format!("wait_for_event error: {e:?}"))?
 		{
 			Event::DestroyNotify(_) => {
 				// This window is being destroyed.
@@ -410,14 +410,14 @@ fn process_server_req(context: &InnerContext) -> Result<()> {
 						.wait_write_data
 						.write()
 						.map(|mut writer| writer.clear())
-						.map_err(|e| format!("write clipboard data error: {:?}", e))?;
+						.map_err(|e| format!("write clipboard data error: {e:?}"))?;
 				}
 			}
 			Event::SelectionRequest(event) => {
 				// Someone is requesting the clipboard content from us.
 				context
 					.handle_selection_request(event)
-					.map_err(|e| format!("handle_selection_request error: {:?}", e))?;
+					.map_err(|e| format!("handle_selection_request error: {e:?}"))?;
 			}
 			Event::SelectionNotify(event) => {
 				// We've requested the clipboard content and this is the answer.


### PR DESCRIPTION
Update version to 0.3.0 in Cargo.toml and documentation. Add changelog for v0.3.0 with iOS support and PR merge. Refactor error formatting in x11.rs to use inline variable interpolation.