### PR TITLE
feat: add Wayland clipboard support via wl-clipboard-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.67.0"
 
 [features]
 image = ["dep:image"]
+wayland = ["dep:wl-clipboard-rs"]
 default = ["image"]
 
 [[example]]
@@ -70,3 +71,4 @@ image = { version = "0.25.5", optional = true, default-features = false, feature
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="ios", target_os="emscripten"))))'.dependencies]
 x11rb = { version = "0.13.2", features = ["xfixes"] }
+wl-clipboard-rs = { version = "0.9", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,15 @@ pub trait ClipboardWatcher<T: ClipboardHandler>: Send {
 	fn get_shutdown_channel(&self) -> WatcherShutdown;
 }
 
+#[cfg(not(all(
+	unix,
+	not(any(
+		target_os = "macos",
+		target_os = "ios",
+		target_os = "android",
+		target_os = "emscripten"
+	))
+)))]
 impl WatcherShutdown {
 	/// zh: 停止监视
 	///

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -56,13 +56,9 @@ pub use x11::ClipboardContextX11Options;
 	))
 ))]
 mod linux_clipboard {
-	use crate::{
-		common::Result, Clipboard, ClipboardContent, ClipboardHandler, ClipboardWatcher,
-		ContentFormat,
-	};
 	#[cfg(feature = "image")]
 	use crate::RustImageData;
-	use std::sync::mpsc::{self, Sender};
+	use crate::{common::Result, Clipboard, ClipboardContent, ClipboardHandler, ContentFormat};
 
 	pub enum ClipboardContext {
 		X11(super::x11::ClipboardContext),
@@ -78,10 +74,7 @@ mod linux_clipboard {
 					match super::wayland::ClipboardContext::new() {
 						Ok(ctx) => return Ok(Self::Wayland(ctx)),
 						Err(e) => {
-							eprintln!(
-								"Wayland clipboard init failed, falling back to X11: {}",
-								e
-							);
+							eprintln!("Wayland clipboard init failed, falling back to X11: {}", e);
 						}
 					}
 				}
@@ -188,10 +181,7 @@ mod linux_clipboard {
 					match super::wayland::ClipboardWatcherContext::new() {
 						Ok(ctx) => return Ok(Self::Wayland(ctx)),
 						Err(e) => {
-							eprintln!(
-								"Wayland watcher init failed, falling back to X11: {}",
-								e
-							);
+							eprintln!("Wayland watcher init failed, falling back to X11: {}", e);
 						}
 					}
 				}
@@ -200,7 +190,7 @@ mod linux_clipboard {
 		}
 	}
 
-	impl<T: ClipboardHandler> crate::ClipboardWatcher<T> for ClipboardWatcherContext<T> {
+	impl<T: ClipboardHandler + Send> crate::ClipboardWatcher<T> for ClipboardWatcherContext<T> {
 		fn add_handler(&mut self, f: T) -> &mut Self {
 			match self {
 				Self::X11(ctx) => {
@@ -239,7 +229,7 @@ mod linux_clipboard {
 		}
 	}
 
-	unsafe impl<T: ClipboardHandler> Send for ClipboardWatcherContext<T> {}
+	unsafe impl<T: ClipboardHandler + Send> Send for ClipboardWatcherContext<T> {}
 
 	enum WatcherShutdownInner {
 		X11(super::x11::WatcherShutdown),

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -10,6 +10,8 @@ pub use macos::{ClipboardContext, ClipboardWatcherContext, WatcherShutdown};
 mod win;
 #[cfg(target_os = "windows")]
 pub use win::{ClipboardContext, ClipboardWatcherContext, WatcherShutdown};
+
+// Linux: runtime detection between Wayland and X11
 #[cfg(all(
 	unix,
 	not(any(
@@ -20,6 +22,19 @@ pub use win::{ClipboardContext, ClipboardWatcherContext, WatcherShutdown};
 	))
 ))]
 mod x11;
+
+#[cfg(all(
+	unix,
+	not(any(
+		target_os = "macos",
+		target_os = "ios",
+		target_os = "android",
+		target_os = "emscripten"
+	)),
+	feature = "wayland"
+))]
+mod wayland;
+
 #[cfg(all(
 	unix,
 	not(any(
@@ -29,6 +44,227 @@ mod x11;
 		target_os = "emscripten"
 	))
 ))]
-pub use x11::{
-	ClipboardContext, ClipboardContextX11Options, ClipboardWatcherContext, WatcherShutdown,
-};
+pub use x11::ClipboardContextX11Options;
+
+#[cfg(all(
+	unix,
+	not(any(
+		target_os = "macos",
+		target_os = "ios",
+		target_os = "android",
+		target_os = "emscripten"
+	))
+))]
+mod linux_clipboard {
+	use crate::{
+		common::Result, Clipboard, ClipboardContent, ClipboardHandler, ClipboardWatcher,
+		ContentFormat,
+	};
+	#[cfg(feature = "image")]
+	use crate::RustImageData;
+	use std::sync::mpsc::{self, Sender};
+
+	pub enum ClipboardContext {
+		X11(super::x11::ClipboardContext),
+		#[cfg(feature = "wayland")]
+		Wayland(super::wayland::ClipboardContext),
+	}
+
+	impl ClipboardContext {
+		pub fn new() -> Result<Self> {
+			#[cfg(feature = "wayland")]
+			{
+				if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+					match super::wayland::ClipboardContext::new() {
+						Ok(ctx) => return Ok(Self::Wayland(ctx)),
+						Err(e) => {
+							eprintln!(
+								"Wayland clipboard init failed, falling back to X11: {}",
+								e
+							);
+						}
+					}
+				}
+			}
+			Ok(Self::X11(super::x11::ClipboardContext::new()?))
+		}
+	}
+
+	macro_rules! dispatch {
+		($self:expr, $method:ident $(, $arg:expr)*) => {
+			match $self {
+				ClipboardContext::X11(ctx) => ctx.$method($($arg),*),
+				#[cfg(feature = "wayland")]
+				ClipboardContext::Wayland(ctx) => ctx.$method($($arg),*),
+			}
+		};
+	}
+
+	impl Clipboard for ClipboardContext {
+		fn available_formats(&self) -> Result<Vec<String>> {
+			dispatch!(self, available_formats)
+		}
+
+		fn has(&self, format: ContentFormat) -> bool {
+			dispatch!(self, has, format)
+		}
+
+		fn clear(&self) -> Result<()> {
+			dispatch!(self, clear)
+		}
+
+		fn get_buffer(&self, format: &str) -> Result<Vec<u8>> {
+			dispatch!(self, get_buffer, format)
+		}
+
+		fn get_text(&self) -> Result<String> {
+			dispatch!(self, get_text)
+		}
+
+		fn get_rich_text(&self) -> Result<String> {
+			dispatch!(self, get_rich_text)
+		}
+
+		fn get_html(&self) -> Result<String> {
+			dispatch!(self, get_html)
+		}
+
+		#[cfg(feature = "image")]
+		fn get_image(&self) -> Result<RustImageData> {
+			dispatch!(self, get_image)
+		}
+
+		fn get_files(&self) -> Result<Vec<String>> {
+			dispatch!(self, get_files)
+		}
+
+		fn get(&self, formats: &[ContentFormat]) -> Result<Vec<ClipboardContent>> {
+			dispatch!(self, get, formats)
+		}
+
+		fn set_buffer(&self, format: &str, buffer: Vec<u8>) -> Result<()> {
+			dispatch!(self, set_buffer, format, buffer)
+		}
+
+		fn set_text(&self, text: String) -> Result<()> {
+			dispatch!(self, set_text, text)
+		}
+
+		fn set_rich_text(&self, text: String) -> Result<()> {
+			dispatch!(self, set_rich_text, text)
+		}
+
+		fn set_html(&self, html: String) -> Result<()> {
+			dispatch!(self, set_html, html)
+		}
+
+		#[cfg(feature = "image")]
+		fn set_image(&self, image: RustImageData) -> Result<()> {
+			dispatch!(self, set_image, image)
+		}
+
+		fn set_files(&self, files: Vec<String>) -> Result<()> {
+			dispatch!(self, set_files, files)
+		}
+
+		fn set(&self, contents: Vec<ClipboardContent>) -> Result<()> {
+			dispatch!(self, set, contents)
+		}
+	}
+
+	unsafe impl Send for ClipboardContext {}
+
+	pub enum ClipboardWatcherContext<T: ClipboardHandler> {
+		X11(super::x11::ClipboardWatcherContext<T>),
+		#[cfg(feature = "wayland")]
+		Wayland(super::wayland::ClipboardWatcherContext<T>),
+	}
+
+	impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
+		pub fn new() -> Result<Self> {
+			#[cfg(feature = "wayland")]
+			{
+				if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+					match super::wayland::ClipboardWatcherContext::new() {
+						Ok(ctx) => return Ok(Self::Wayland(ctx)),
+						Err(e) => {
+							eprintln!(
+								"Wayland watcher init failed, falling back to X11: {}",
+								e
+							);
+						}
+					}
+				}
+			}
+			Ok(Self::X11(super::x11::ClipboardWatcherContext::new()?))
+		}
+	}
+
+	impl<T: ClipboardHandler> crate::ClipboardWatcher<T> for ClipboardWatcherContext<T> {
+		fn add_handler(&mut self, f: T) -> &mut Self {
+			match self {
+				Self::X11(ctx) => {
+					ctx.handlers.push(f);
+				}
+				#[cfg(feature = "wayland")]
+				Self::Wayland(ctx) => {
+					ctx.handlers.push(f);
+				}
+			}
+			self
+		}
+
+		fn start_watch(&mut self) {
+			match self {
+				Self::X11(ctx) => ctx.start_watch_inner(),
+				#[cfg(feature = "wayland")]
+				Self::Wayland(ctx) => ctx.start_watch_inner(),
+			}
+		}
+
+		fn get_shutdown_channel(&self) -> WatcherShutdown {
+			match self {
+				Self::X11(ctx) => WatcherShutdown {
+					_inner: WatcherShutdownInner::X11(super::x11::WatcherShutdown {
+						sender: ctx.stop_signal.clone(),
+					}),
+				},
+				#[cfg(feature = "wayland")]
+				Self::Wayland(ctx) => WatcherShutdown {
+					_inner: WatcherShutdownInner::Wayland(super::wayland::WatcherShutdown {
+						sender: ctx.stop_signal.clone(),
+					}),
+				},
+			}
+		}
+	}
+
+	unsafe impl<T: ClipboardHandler> Send for ClipboardWatcherContext<T> {}
+
+	enum WatcherShutdownInner {
+		X11(super::x11::WatcherShutdown),
+		#[cfg(feature = "wayland")]
+		Wayland(super::wayland::WatcherShutdown),
+	}
+
+	pub struct WatcherShutdown {
+		_inner: WatcherShutdownInner,
+	}
+
+	impl WatcherShutdown {
+		pub fn stop(self) {
+			drop(self);
+		}
+	}
+}
+
+#[cfg(all(
+	unix,
+	not(any(
+		target_os = "macos",
+		target_os = "ios",
+		target_os = "android",
+		target_os = "emscripten"
+	))
+))]
+pub use linux_clipboard::{ClipboardContext, ClipboardWatcherContext, WatcherShutdown};

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -215,15 +215,11 @@ mod linux_clipboard {
 		fn get_shutdown_channel(&self) -> WatcherShutdown {
 			match self {
 				Self::X11(ctx) => WatcherShutdown {
-					_inner: WatcherShutdownInner::X11(super::x11::WatcherShutdown {
-						sender: ctx.stop_signal.clone(),
-					}),
+					_shutdown: Box::new(ctx.get_shutdown_channel()),
 				},
 				#[cfg(feature = "wayland")]
 				Self::Wayland(ctx) => WatcherShutdown {
-					_inner: WatcherShutdownInner::Wayland(super::wayland::WatcherShutdown {
-						sender: ctx.stop_signal.clone(),
-					}),
+					_shutdown: Box::new(ctx.get_shutdown_channel()),
 				},
 			}
 		}
@@ -231,14 +227,8 @@ mod linux_clipboard {
 
 	unsafe impl<T: ClipboardHandler + Send> Send for ClipboardWatcherContext<T> {}
 
-	enum WatcherShutdownInner {
-		X11(super::x11::WatcherShutdown),
-		#[cfg(feature = "wayland")]
-		Wayland(super::wayland::WatcherShutdown),
-	}
-
 	pub struct WatcherShutdown {
-		_inner: WatcherShutdownInner,
+		_shutdown: Box<dyn std::any::Any + Send>,
 	}
 
 	impl WatcherShutdown {

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -296,6 +296,9 @@ unsafe impl<T: ClipboardHandler> Send for ClipboardWatcherContext<T> {}
 
 impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
     pub fn new() -> Result<Self> {
+        // Verify data-control protocol is available (same check as ClipboardContext)
+        is_primary_selection_supported()
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
         let (tx, rx) = mpsc::channel();
         Ok(Self {
             handlers: Vec::new(),

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -1,0 +1,369 @@
+use crate::{
+    common::Result,
+    ClipboardContent, ClipboardHandler, ContentFormat,
+};
+
+#[cfg(feature = "image")]
+use crate::{common::RustImage, RustImageData};
+
+use crate::Clipboard;
+use std::io::Read;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread;
+use std::time::Duration;
+use wl_clipboard_rs::{
+    copy::{self, MimeSource, MimeType, Options, Source},
+    paste::{self, get_contents, Seat},
+    utils::is_primary_selection_supported,
+};
+
+const MIME_TEXT: &str = "text/plain;charset=utf-8";
+const MIME_HTML: &str = "text/html";
+const MIME_RTF: &str = "text/rtf";
+const MIME_PNG: &str = "image/png";
+const MIME_URI_LIST: &str = "text/uri-list";
+
+fn read_wayland_clipboard(mime: paste::MimeType) -> Result<Vec<u8>> {
+    let result = get_contents(
+        paste::ClipboardType::Regular,
+        Seat::Unspecified,
+        mime,
+    );
+    match result {
+        Ok((mut pipe, _)) => {
+            let mut buffer = vec![];
+            pipe.read_to_end(&mut buffer)
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
+            Ok(buffer)
+        }
+        Err(paste::Error::ClipboardEmpty) | Err(paste::Error::NoMimeType) => {
+            Err("Clipboard is empty or content type not available".into())
+        }
+        Err(e) => Err(e.to_string().into()),
+    }
+}
+
+fn write_wayland_clipboard(sources: Vec<MimeSource>) -> Result<()> {
+    let mut opts = Options::new();
+    opts.foreground(false);
+    opts.clipboard(copy::ClipboardType::Regular);
+    opts.copy_multi(sources)
+        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
+    Ok(())
+}
+
+pub struct ClipboardContext;
+
+impl ClipboardContext {
+    pub fn new() -> Result<Self> {
+        match is_primary_selection_supported() {
+            Ok(_) => Ok(Self),
+            Err(e) => Err(e.to_string().into()),
+        }
+    }
+}
+
+impl Clipboard for ClipboardContext {
+    fn available_formats(&self) -> Result<Vec<String>> {
+        // wl-clipboard-rs doesn't provide a way to list formats directly
+        // Try known formats and report which ones are available
+        let mut formats = Vec::new();
+        if self.has(ContentFormat::Text) {
+            formats.push("text/plain".to_string());
+        }
+        if self.has(ContentFormat::Html) {
+            formats.push(MIME_HTML.to_string());
+        }
+        if self.has(ContentFormat::Rtf) {
+            formats.push(MIME_RTF.to_string());
+        }
+        if self.has(ContentFormat::Image) {
+            formats.push(MIME_PNG.to_string());
+        }
+        if self.has(ContentFormat::Files) {
+            formats.push(MIME_URI_LIST.to_string());
+        }
+        Ok(formats)
+    }
+
+    fn has(&self, format: ContentFormat) -> bool {
+        let mime = match format {
+            ContentFormat::Text => paste::MimeType::Text,
+            ContentFormat::Html => paste::MimeType::Specific(MIME_HTML),
+            ContentFormat::Rtf => paste::MimeType::Specific(MIME_RTF),
+            ContentFormat::Image => paste::MimeType::Specific(MIME_PNG),
+            ContentFormat::Files => paste::MimeType::Specific(MIME_URI_LIST),
+            ContentFormat::Other(ref s) => paste::MimeType::Specific(s.as_str()),
+        };
+        read_wayland_clipboard(mime).is_ok()
+    }
+
+    fn clear(&self) -> Result<()> {
+        copy::clear(copy::ClipboardType::Regular, copy::Seat::All)
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
+        Ok(())
+    }
+
+    fn get_buffer(&self, format: &str) -> Result<Vec<u8>> {
+        read_wayland_clipboard(paste::MimeType::Specific(format))
+    }
+
+    fn get_text(&self) -> Result<String> {
+        let bytes = read_wayland_clipboard(paste::MimeType::Text)?;
+        String::from_utf8(bytes)
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })
+    }
+
+    fn get_rich_text(&self) -> Result<String> {
+        let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_RTF))?;
+        String::from_utf8(bytes)
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })
+    }
+
+    fn get_html(&self) -> Result<String> {
+        let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_HTML))?;
+        String::from_utf8(bytes)
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })
+    }
+
+    #[cfg(feature = "image")]
+    fn get_image(&self) -> Result<RustImageData> {
+        let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_PNG))?;
+        RustImageData::from_bytes(&bytes)
+    }
+
+    fn get_files(&self) -> Result<Vec<String>> {
+        let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_URI_LIST))?;
+        let text = String::from_utf8(bytes)
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
+        Ok(text
+            .lines()
+            .filter(|line| !line.starts_with('#') && !line.is_empty())
+            .map(|line| line.to_string())
+            .collect())
+    }
+
+    fn get(&self, formats: &[ContentFormat]) -> Result<Vec<ClipboardContent>> {
+        let mut contents = Vec::new();
+        for format in formats {
+            match format {
+                ContentFormat::Text => {
+                    if let Ok(text) = self.get_text() {
+                        contents.push(ClipboardContent::Text(text));
+                    }
+                }
+                ContentFormat::Html => {
+                    if let Ok(html) = self.get_html() {
+                        contents.push(ClipboardContent::Html(html));
+                    }
+                }
+                ContentFormat::Rtf => {
+                    if let Ok(rtf) = self.get_rich_text() {
+                        contents.push(ClipboardContent::Rtf(rtf));
+                    }
+                }
+                #[cfg(feature = "image")]
+                ContentFormat::Image => {
+                    if let Ok(image) = self.get_image() {
+                        contents.push(ClipboardContent::Image(image));
+                    }
+                }
+                ContentFormat::Files => {
+                    if let Ok(files) = self.get_files() {
+                        contents.push(ClipboardContent::Files(files));
+                    }
+                }
+                ContentFormat::Other(mime) => {
+                    if let Ok(data) = self.get_buffer(mime) {
+                        contents.push(ClipboardContent::Other(mime.clone(), data));
+                    }
+                }
+                #[cfg(not(feature = "image"))]
+                _ => {}
+            }
+        }
+        Ok(contents)
+    }
+
+    fn set_buffer(&self, format: &str, buffer: Vec<u8>) -> Result<()> {
+        write_wayland_clipboard(vec![MimeSource {
+            source: Source::Bytes(buffer.into_boxed_slice()),
+            mime_type: MimeType::Specific(format.to_string()),
+        }])
+    }
+
+    fn set_text(&self, text: String) -> Result<()> {
+        write_wayland_clipboard(vec![MimeSource {
+            source: Source::Bytes(text.into_bytes().into_boxed_slice()),
+            mime_type: MimeType::Text,
+        }])
+    }
+
+    fn set_rich_text(&self, text: String) -> Result<()> {
+        write_wayland_clipboard(vec![MimeSource {
+            source: Source::Bytes(text.into_bytes().into_boxed_slice()),
+            mime_type: MimeType::Specific(MIME_RTF.to_string()),
+        }])
+    }
+
+    fn set_html(&self, html: String) -> Result<()> {
+        write_wayland_clipboard(vec![
+            MimeSource {
+                source: Source::Bytes(html.into_bytes().into_boxed_slice()),
+                mime_type: MimeType::Specific(MIME_HTML.to_string()),
+            },
+        ])
+    }
+
+    #[cfg(feature = "image")]
+    fn set_image(&self, image: RustImageData) -> Result<()> {
+        let bytes = image.to_png()?;
+        write_wayland_clipboard(vec![MimeSource {
+            source: Source::Bytes(bytes.get_bytes().into()),
+            mime_type: MimeType::Specific(MIME_PNG.to_string()),
+        }])
+    }
+
+    fn set_files(&self, files: Vec<String>) -> Result<()> {
+        let uri_list = files.join("\n");
+        write_wayland_clipboard(vec![MimeSource {
+            source: Source::Bytes(uri_list.into_bytes().into_boxed_slice()),
+            mime_type: MimeType::Specific(MIME_URI_LIST.to_string()),
+        }])
+    }
+
+    fn set(&self, contents: Vec<ClipboardContent>) -> Result<()> {
+        let mut sources = Vec::new();
+        for content in contents {
+            match content {
+                ClipboardContent::Text(text) => {
+                    sources.push(MimeSource {
+                        source: Source::Bytes(text.into_bytes().into_boxed_slice()),
+                        mime_type: MimeType::Text,
+                    });
+                }
+                ClipboardContent::Html(html) => {
+                    sources.push(MimeSource {
+                        source: Source::Bytes(html.into_bytes().into_boxed_slice()),
+                        mime_type: MimeType::Specific(MIME_HTML.to_string()),
+                    });
+                }
+                ClipboardContent::Rtf(rtf) => {
+                    sources.push(MimeSource {
+                        source: Source::Bytes(rtf.into_bytes().into_boxed_slice()),
+                        mime_type: MimeType::Specific(MIME_RTF.to_string()),
+                    });
+                }
+                #[cfg(feature = "image")]
+                ClipboardContent::Image(image) => {
+                    let bytes = image.to_png()?;
+                    sources.push(MimeSource {
+                        source: Source::Bytes(bytes.get_bytes().into()),
+                        mime_type: MimeType::Specific(MIME_PNG.to_string()),
+                    });
+                }
+                ClipboardContent::Files(files) => {
+                    let uri_list = files.join("\n");
+                    sources.push(MimeSource {
+                        source: Source::Bytes(uri_list.into_bytes().into_boxed_slice()),
+                        mime_type: MimeType::Specific(MIME_URI_LIST.to_string()),
+                    });
+                }
+                ClipboardContent::Other(mime, data) => {
+                    sources.push(MimeSource {
+                        source: Source::Bytes(data.into_boxed_slice()),
+                        mime_type: MimeType::Specific(mime),
+                    });
+                }
+                #[cfg(not(feature = "image"))]
+                _ => {}
+            }
+        }
+        write_wayland_clipboard(sources)
+    }
+}
+
+unsafe impl Send for ClipboardContext {}
+
+// Polling-based clipboard watcher for Wayland
+pub struct ClipboardWatcherContext<T: ClipboardHandler> {
+    pub(crate) handlers: Vec<T>,
+    pub(crate) stop_signal: Sender<()>,
+    stop_receiver: Receiver<()>,
+}
+
+unsafe impl<T: ClipboardHandler> Send for ClipboardWatcherContext<T> {}
+
+impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
+    pub fn new() -> Result<Self> {
+        let (tx, rx) = mpsc::channel();
+        Ok(Self {
+            handlers: Vec::new(),
+            stop_signal: tx,
+            stop_receiver: rx,
+        })
+    }
+}
+
+impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
+    pub(crate) fn start_watch_inner(&mut self) {
+        let mut last_text = String::new();
+
+        // Get initial clipboard content
+        if let Ok(text) = read_wayland_clipboard(paste::MimeType::Text) {
+            if let Ok(s) = String::from_utf8(text) {
+                last_text = s;
+            }
+        }
+
+        loop {
+            if self
+                .stop_receiver
+                .recv_timeout(Duration::from_millis(500))
+                .is_ok()
+            {
+                break;
+            }
+
+            let changed = if let Ok(bytes) = read_wayland_clipboard(paste::MimeType::Text) {
+                if let Ok(current) = String::from_utf8(bytes) {
+                    if current != last_text {
+                        last_text = current;
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            } else {
+                // Clipboard might be empty or have non-text content
+                if !last_text.is_empty() {
+                    last_text.clear();
+                    true
+                } else {
+                    false
+                }
+            };
+
+            if changed {
+                self.handlers
+                    .iter_mut()
+                    .for_each(|handler| handler.on_clipboard_change());
+            }
+        }
+    }
+
+}
+
+// get_shutdown_channel is handled by the linux_clipboard wrapper in mod.rs
+
+pub struct WatcherShutdown {
+    pub(crate) sender: Sender<()>,
+}
+
+impl Drop for WatcherShutdown {
+    fn drop(&mut self) {
+        let _ = self.sender.send(());
+    }
+}

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -327,6 +327,12 @@ impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 }
 
 impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
+	pub(crate) fn get_shutdown_channel(&self) -> WatcherShutdown {
+		WatcherShutdown {
+			sender: self.stop_signal.clone(),
+		}
+	}
+
 	pub(crate) fn start_watch_inner(&mut self) {
 		let mut last_mime_types: Vec<String> = Vec::new();
 		let mut last_text = String::new();
@@ -407,8 +413,6 @@ impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 		}
 	}
 }
-
-// get_shutdown_channel is handled by the linux_clipboard wrapper in mod.rs
 
 pub struct WatcherShutdown {
 	pub(crate) sender: Sender<()>,

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -1,372 +1,421 @@
-use crate::{
-    common::Result,
-    ClipboardContent, ClipboardHandler, ContentFormat,
-};
+use crate::{common::Result, Clipboard, ClipboardContent, ClipboardHandler, ContentFormat};
 
 #[cfg(feature = "image")]
 use crate::{common::RustImage, RustImageData};
 
-use crate::Clipboard;
 use std::io::Read;
 use std::sync::mpsc::{self, Receiver, Sender};
-use std::thread;
 use std::time::Duration;
 use wl_clipboard_rs::{
-    copy::{self, MimeSource, MimeType, Options, Source},
-    paste::{self, get_contents, Seat},
-    utils::is_primary_selection_supported,
+	copy::{self, MimeSource, MimeType, Options, Source},
+	paste::{self, get_contents, get_mime_types, ClipboardType, Seat},
+	utils::is_primary_selection_supported,
 };
 
-const MIME_TEXT: &str = "text/plain;charset=utf-8";
 const MIME_HTML: &str = "text/html";
 const MIME_RTF: &str = "text/rtf";
+#[cfg(feature = "image")]
 const MIME_PNG: &str = "image/png";
 const MIME_URI_LIST: &str = "text/uri-list";
+const FILE_PATH_PREFIX: &str = "file://";
 
 fn read_wayland_clipboard(mime: paste::MimeType) -> Result<Vec<u8>> {
-    let result = get_contents(
-        paste::ClipboardType::Regular,
-        Seat::Unspecified,
-        mime,
-    );
-    match result {
-        Ok((mut pipe, _)) => {
-            let mut buffer = vec![];
-            pipe.read_to_end(&mut buffer)
-                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
-            Ok(buffer)
-        }
-        Err(paste::Error::ClipboardEmpty) | Err(paste::Error::NoMimeType) => {
-            Err("Clipboard is empty or content type not available".into())
-        }
-        Err(e) => Err(e.to_string().into()),
-    }
+	let result = get_contents(ClipboardType::Regular, Seat::Unspecified, mime);
+	match result {
+		Ok((mut pipe, _)) => {
+			let mut buffer = vec![];
+			pipe.read_to_end(&mut buffer).map_err(
+				|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() },
+			)?;
+			Ok(buffer)
+		}
+		Err(paste::Error::ClipboardEmpty) | Err(paste::Error::NoMimeType) => {
+			Err("Clipboard is empty or content type not available".into())
+		}
+		Err(e) => Err(e.to_string().into()),
+	}
 }
 
 fn write_wayland_clipboard(sources: Vec<MimeSource>) -> Result<()> {
-    let mut opts = Options::new();
-    opts.foreground(false);
-    opts.clipboard(copy::ClipboardType::Regular);
-    opts.copy_multi(sources)
-        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
-    Ok(())
+	let mut opts = Options::new();
+	opts.foreground(false);
+	opts.clipboard(copy::ClipboardType::Regular);
+	opts.copy_multi(sources)
+		.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
+	Ok(())
+}
+
+fn get_offered_mime_types() -> Result<std::collections::HashSet<String>> {
+	get_mime_types(ClipboardType::Regular, Seat::Unspecified)
+		.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })
 }
 
 pub struct ClipboardContext;
 
 impl ClipboardContext {
-    pub fn new() -> Result<Self> {
-        match is_primary_selection_supported() {
-            Ok(_) => Ok(Self),
-            Err(e) => Err(e.to_string().into()),
-        }
-    }
+	pub fn new() -> Result<Self> {
+		match is_primary_selection_supported() {
+			Ok(_) => Ok(Self),
+			Err(e) => Err(e.to_string().into()),
+		}
+	}
 }
 
 impl Clipboard for ClipboardContext {
-    fn available_formats(&self) -> Result<Vec<String>> {
-        // wl-clipboard-rs doesn't provide a way to list formats directly
-        // Try known formats and report which ones are available
-        let mut formats = Vec::new();
-        if self.has(ContentFormat::Text) {
-            formats.push("text/plain".to_string());
-        }
-        if self.has(ContentFormat::Html) {
-            formats.push(MIME_HTML.to_string());
-        }
-        if self.has(ContentFormat::Rtf) {
-            formats.push(MIME_RTF.to_string());
-        }
-        if self.has(ContentFormat::Image) {
-            formats.push(MIME_PNG.to_string());
-        }
-        if self.has(ContentFormat::Files) {
-            formats.push(MIME_URI_LIST.to_string());
-        }
-        Ok(formats)
-    }
+	fn available_formats(&self) -> Result<Vec<String>> {
+		let mime_types = get_offered_mime_types()?;
+		Ok(mime_types.into_iter().collect())
+	}
 
-    fn has(&self, format: ContentFormat) -> bool {
-        let mime = match format {
-            ContentFormat::Text => paste::MimeType::Text,
-            ContentFormat::Html => paste::MimeType::Specific(MIME_HTML),
-            ContentFormat::Rtf => paste::MimeType::Specific(MIME_RTF),
-            ContentFormat::Image => paste::MimeType::Specific(MIME_PNG),
-            ContentFormat::Files => paste::MimeType::Specific(MIME_URI_LIST),
-            ContentFormat::Other(ref s) => paste::MimeType::Specific(s.as_str()),
-        };
-        read_wayland_clipboard(mime).is_ok()
-    }
+	fn has(&self, format: ContentFormat) -> bool {
+		#[allow(unreachable_patterns)]
+		let mime_to_check = match format {
+			ContentFormat::Text => "text/plain",
+			ContentFormat::Html => MIME_HTML,
+			ContentFormat::Rtf => MIME_RTF,
+			#[cfg(feature = "image")]
+			ContentFormat::Image => MIME_PNG,
+			ContentFormat::Files => MIME_URI_LIST,
+			ContentFormat::Other(ref s) => s.as_str(),
+			#[cfg(not(feature = "image"))]
+			_ => return false,
+		};
+		if let Ok(mime_types) = get_offered_mime_types() {
+			// For text, also check text/plain;charset=utf-8
+			if mime_to_check == "text/plain" {
+				mime_types.iter().any(|m| m.starts_with("text/plain"))
+			} else {
+				mime_types.contains(mime_to_check)
+			}
+		} else {
+			false
+		}
+	}
 
-    fn clear(&self) -> Result<()> {
-        copy::clear(copy::ClipboardType::Regular, copy::Seat::All)
-            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
-        Ok(())
-    }
+	fn clear(&self) -> Result<()> {
+		copy::clear(copy::ClipboardType::Regular, copy::Seat::All)
+			.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
+		Ok(())
+	}
 
-    fn get_buffer(&self, format: &str) -> Result<Vec<u8>> {
-        read_wayland_clipboard(paste::MimeType::Specific(format))
-    }
+	fn get_buffer(&self, format: &str) -> Result<Vec<u8>> {
+		read_wayland_clipboard(paste::MimeType::Specific(format))
+	}
 
-    fn get_text(&self) -> Result<String> {
-        let bytes = read_wayland_clipboard(paste::MimeType::Text)?;
-        String::from_utf8(bytes)
-            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })
-    }
+	fn get_text(&self) -> Result<String> {
+		let bytes = read_wayland_clipboard(paste::MimeType::Text)?;
+		String::from_utf8(bytes)
+			.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })
+	}
 
-    fn get_rich_text(&self) -> Result<String> {
-        let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_RTF))?;
-        String::from_utf8(bytes)
-            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })
-    }
+	fn get_rich_text(&self) -> Result<String> {
+		let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_RTF))?;
+		String::from_utf8(bytes)
+			.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })
+	}
 
-    fn get_html(&self) -> Result<String> {
-        let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_HTML))?;
-        String::from_utf8(bytes)
-            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })
-    }
+	fn get_html(&self) -> Result<String> {
+		let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_HTML))?;
+		String::from_utf8(bytes)
+			.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })
+	}
 
-    #[cfg(feature = "image")]
-    fn get_image(&self) -> Result<RustImageData> {
-        let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_PNG))?;
-        RustImageData::from_bytes(&bytes)
-    }
+	#[cfg(feature = "image")]
+	fn get_image(&self) -> Result<RustImageData> {
+		let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_PNG))?;
+		RustImageData::from_bytes(&bytes)
+	}
 
-    fn get_files(&self) -> Result<Vec<String>> {
-        let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_URI_LIST))?;
-        let text = String::from_utf8(bytes)
-            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
-        Ok(text
-            .lines()
-            .filter(|line| !line.starts_with('#') && !line.is_empty())
-            .map(|line| line.to_string())
-            .collect())
-    }
+	fn get_files(&self) -> Result<Vec<String>> {
+		let bytes = read_wayland_clipboard(paste::MimeType::Specific(MIME_URI_LIST))?;
+		let text = String::from_utf8(bytes)
+			.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
+		Ok(text
+			.lines()
+			.map(|line| line.trim_end_matches('\r'))
+			.filter(|line| {
+				!line.starts_with('#') && !line.is_empty() && line.starts_with(FILE_PATH_PREFIX)
+			})
+			.map(|line| line.to_string())
+			.collect())
+	}
 
-    fn get(&self, formats: &[ContentFormat]) -> Result<Vec<ClipboardContent>> {
-        let mut contents = Vec::new();
-        for format in formats {
-            match format {
-                ContentFormat::Text => {
-                    if let Ok(text) = self.get_text() {
-                        contents.push(ClipboardContent::Text(text));
-                    }
-                }
-                ContentFormat::Html => {
-                    if let Ok(html) = self.get_html() {
-                        contents.push(ClipboardContent::Html(html));
-                    }
-                }
-                ContentFormat::Rtf => {
-                    if let Ok(rtf) = self.get_rich_text() {
-                        contents.push(ClipboardContent::Rtf(rtf));
-                    }
-                }
-                #[cfg(feature = "image")]
-                ContentFormat::Image => {
-                    if let Ok(image) = self.get_image() {
-                        contents.push(ClipboardContent::Image(image));
-                    }
-                }
-                ContentFormat::Files => {
-                    if let Ok(files) = self.get_files() {
-                        contents.push(ClipboardContent::Files(files));
-                    }
-                }
-                ContentFormat::Other(mime) => {
-                    if let Ok(data) = self.get_buffer(mime) {
-                        contents.push(ClipboardContent::Other(mime.clone(), data));
-                    }
-                }
-                #[cfg(not(feature = "image"))]
-                _ => {}
-            }
-        }
-        Ok(contents)
-    }
+	fn get(&self, formats: &[ContentFormat]) -> Result<Vec<ClipboardContent>> {
+		let mut contents = Vec::new();
+		for format in formats {
+			#[allow(unreachable_patterns)]
+			match format {
+				ContentFormat::Text => {
+					if let Ok(text) = self.get_text() {
+						contents.push(ClipboardContent::Text(text));
+					}
+				}
+				ContentFormat::Html => {
+					if let Ok(html) = self.get_html() {
+						contents.push(ClipboardContent::Html(html));
+					}
+				}
+				ContentFormat::Rtf => {
+					if let Ok(rtf) = self.get_rich_text() {
+						contents.push(ClipboardContent::Rtf(rtf));
+					}
+				}
+				#[cfg(feature = "image")]
+				ContentFormat::Image => {
+					if let Ok(image) = self.get_image() {
+						contents.push(ClipboardContent::Image(image));
+					}
+				}
+				ContentFormat::Files => {
+					if let Ok(files) = self.get_files() {
+						contents.push(ClipboardContent::Files(files));
+					}
+				}
+				ContentFormat::Other(mime) => {
+					if let Ok(data) = self.get_buffer(mime) {
+						contents.push(ClipboardContent::Other(mime.clone(), data));
+					}
+				}
+				#[cfg(not(feature = "image"))]
+				_ => {}
+			}
+		}
+		Ok(contents)
+	}
 
-    fn set_buffer(&self, format: &str, buffer: Vec<u8>) -> Result<()> {
-        write_wayland_clipboard(vec![MimeSource {
-            source: Source::Bytes(buffer.into_boxed_slice()),
-            mime_type: MimeType::Specific(format.to_string()),
-        }])
-    }
+	fn set_buffer(&self, format: &str, buffer: Vec<u8>) -> Result<()> {
+		write_wayland_clipboard(vec![MimeSource {
+			source: Source::Bytes(buffer.into_boxed_slice()),
+			mime_type: MimeType::Specific(format.to_string()),
+		}])
+	}
 
-    fn set_text(&self, text: String) -> Result<()> {
-        write_wayland_clipboard(vec![MimeSource {
-            source: Source::Bytes(text.into_bytes().into_boxed_slice()),
-            mime_type: MimeType::Text,
-        }])
-    }
+	fn set_text(&self, text: String) -> Result<()> {
+		write_wayland_clipboard(vec![MimeSource {
+			source: Source::Bytes(text.into_bytes().into_boxed_slice()),
+			mime_type: MimeType::Text,
+		}])
+	}
 
-    fn set_rich_text(&self, text: String) -> Result<()> {
-        write_wayland_clipboard(vec![MimeSource {
-            source: Source::Bytes(text.into_bytes().into_boxed_slice()),
-            mime_type: MimeType::Specific(MIME_RTF.to_string()),
-        }])
-    }
+	fn set_rich_text(&self, text: String) -> Result<()> {
+		write_wayland_clipboard(vec![MimeSource {
+			source: Source::Bytes(text.into_bytes().into_boxed_slice()),
+			mime_type: MimeType::Specific(MIME_RTF.to_string()),
+		}])
+	}
 
-    fn set_html(&self, html: String) -> Result<()> {
-        write_wayland_clipboard(vec![
-            MimeSource {
-                source: Source::Bytes(html.into_bytes().into_boxed_slice()),
-                mime_type: MimeType::Specific(MIME_HTML.to_string()),
-            },
-        ])
-    }
+	fn set_html(&self, html: String) -> Result<()> {
+		write_wayland_clipboard(vec![MimeSource {
+			source: Source::Bytes(html.into_bytes().into_boxed_slice()),
+			mime_type: MimeType::Specific(MIME_HTML.to_string()),
+		}])
+	}
 
-    #[cfg(feature = "image")]
-    fn set_image(&self, image: RustImageData) -> Result<()> {
-        let bytes = image.to_png()?;
-        write_wayland_clipboard(vec![MimeSource {
-            source: Source::Bytes(bytes.get_bytes().into()),
-            mime_type: MimeType::Specific(MIME_PNG.to_string()),
-        }])
-    }
+	#[cfg(feature = "image")]
+	fn set_image(&self, image: RustImageData) -> Result<()> {
+		let bytes = image.to_png()?;
+		write_wayland_clipboard(vec![MimeSource {
+			source: Source::Bytes(bytes.get_bytes().into()),
+			mime_type: MimeType::Specific(MIME_PNG.to_string()),
+		}])
+	}
 
-    fn set_files(&self, files: Vec<String>) -> Result<()> {
-        let uri_list = files.join("\n");
-        write_wayland_clipboard(vec![MimeSource {
-            source: Source::Bytes(uri_list.into_bytes().into_boxed_slice()),
-            mime_type: MimeType::Specific(MIME_URI_LIST.to_string()),
-        }])
-    }
+	fn set_files(&self, files: Vec<String>) -> Result<()> {
+		// Normalize paths to file:// URIs and use CRLF for text/uri-list
+		let uri_list: Vec<String> = files
+			.into_iter()
+			.map(|f| {
+				if f.starts_with(FILE_PATH_PREFIX) {
+					f
+				} else {
+					format!("{FILE_PATH_PREFIX}{f}")
+				}
+			})
+			.collect();
+		let data = uri_list.join("\r\n");
+		write_wayland_clipboard(vec![MimeSource {
+			source: Source::Bytes(data.into_bytes().into_boxed_slice()),
+			mime_type: MimeType::Specific(MIME_URI_LIST.to_string()),
+		}])
+	}
 
-    fn set(&self, contents: Vec<ClipboardContent>) -> Result<()> {
-        let mut sources = Vec::new();
-        for content in contents {
-            match content {
-                ClipboardContent::Text(text) => {
-                    sources.push(MimeSource {
-                        source: Source::Bytes(text.into_bytes().into_boxed_slice()),
-                        mime_type: MimeType::Text,
-                    });
-                }
-                ClipboardContent::Html(html) => {
-                    sources.push(MimeSource {
-                        source: Source::Bytes(html.into_bytes().into_boxed_slice()),
-                        mime_type: MimeType::Specific(MIME_HTML.to_string()),
-                    });
-                }
-                ClipboardContent::Rtf(rtf) => {
-                    sources.push(MimeSource {
-                        source: Source::Bytes(rtf.into_bytes().into_boxed_slice()),
-                        mime_type: MimeType::Specific(MIME_RTF.to_string()),
-                    });
-                }
-                #[cfg(feature = "image")]
-                ClipboardContent::Image(image) => {
-                    let bytes = image.to_png()?;
-                    sources.push(MimeSource {
-                        source: Source::Bytes(bytes.get_bytes().into()),
-                        mime_type: MimeType::Specific(MIME_PNG.to_string()),
-                    });
-                }
-                ClipboardContent::Files(files) => {
-                    let uri_list = files.join("\n");
-                    sources.push(MimeSource {
-                        source: Source::Bytes(uri_list.into_bytes().into_boxed_slice()),
-                        mime_type: MimeType::Specific(MIME_URI_LIST.to_string()),
-                    });
-                }
-                ClipboardContent::Other(mime, data) => {
-                    sources.push(MimeSource {
-                        source: Source::Bytes(data.into_boxed_slice()),
-                        mime_type: MimeType::Specific(mime),
-                    });
-                }
-                #[cfg(not(feature = "image"))]
-                _ => {}
-            }
-        }
-        write_wayland_clipboard(sources)
-    }
+	fn set(&self, contents: Vec<ClipboardContent>) -> Result<()> {
+		let mut sources = Vec::new();
+		for content in contents {
+			#[allow(unreachable_patterns)]
+			match content {
+				ClipboardContent::Text(text) => {
+					sources.push(MimeSource {
+						source: Source::Bytes(text.into_bytes().into_boxed_slice()),
+						mime_type: MimeType::Text,
+					});
+				}
+				ClipboardContent::Html(html) => {
+					sources.push(MimeSource {
+						source: Source::Bytes(html.into_bytes().into_boxed_slice()),
+						mime_type: MimeType::Specific(MIME_HTML.to_string()),
+					});
+				}
+				ClipboardContent::Rtf(rtf) => {
+					sources.push(MimeSource {
+						source: Source::Bytes(rtf.into_bytes().into_boxed_slice()),
+						mime_type: MimeType::Specific(MIME_RTF.to_string()),
+					});
+				}
+				#[cfg(feature = "image")]
+				ClipboardContent::Image(image) => {
+					let bytes = image.to_png()?;
+					sources.push(MimeSource {
+						source: Source::Bytes(bytes.get_bytes().into()),
+						mime_type: MimeType::Specific(MIME_PNG.to_string()),
+					});
+				}
+				ClipboardContent::Files(files) => {
+					let uri_list: Vec<String> = files
+						.into_iter()
+						.map(|f| {
+							if f.starts_with(FILE_PATH_PREFIX) {
+								f
+							} else {
+								format!("{FILE_PATH_PREFIX}{f}")
+							}
+						})
+						.collect();
+					let data = uri_list.join("\r\n");
+					sources.push(MimeSource {
+						source: Source::Bytes(data.into_bytes().into_boxed_slice()),
+						mime_type: MimeType::Specific(MIME_URI_LIST.to_string()),
+					});
+				}
+				ClipboardContent::Other(mime, data) => {
+					sources.push(MimeSource {
+						source: Source::Bytes(data.into_boxed_slice()),
+						mime_type: MimeType::Specific(mime),
+					});
+				}
+				#[cfg(not(feature = "image"))]
+				_ => {}
+			}
+		}
+		write_wayland_clipboard(sources)
+	}
 }
 
 unsafe impl Send for ClipboardContext {}
 
 // Polling-based clipboard watcher for Wayland
 pub struct ClipboardWatcherContext<T: ClipboardHandler> {
-    pub(crate) handlers: Vec<T>,
-    pub(crate) stop_signal: Sender<()>,
-    stop_receiver: Receiver<()>,
+	pub(crate) handlers: Vec<T>,
+	pub(crate) stop_signal: Sender<()>,
+	stop_receiver: Receiver<()>,
 }
 
-unsafe impl<T: ClipboardHandler> Send for ClipboardWatcherContext<T> {}
+unsafe impl<T: ClipboardHandler + Send> Send for ClipboardWatcherContext<T> {}
 
 impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
-    pub fn new() -> Result<Self> {
-        // Verify data-control protocol is available (same check as ClipboardContext)
-        is_primary_selection_supported()
-            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
-        let (tx, rx) = mpsc::channel();
-        Ok(Self {
-            handlers: Vec::new(),
-            stop_signal: tx,
-            stop_receiver: rx,
-        })
-    }
+	pub fn new() -> Result<Self> {
+		// Verify data-control protocol is available (same check as ClipboardContext)
+		is_primary_selection_supported()
+			.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
+		let (tx, rx) = mpsc::channel();
+		Ok(Self {
+			handlers: Vec::new(),
+			stop_signal: tx,
+			stop_receiver: rx,
+		})
+	}
 }
 
 impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
-    pub(crate) fn start_watch_inner(&mut self) {
-        let mut last_text = String::new();
+	pub(crate) fn start_watch_inner(&mut self) {
+		let mut last_mime_types: Vec<String> = Vec::new();
+		let mut last_text = String::new();
 
-        // Get initial clipboard content
-        if let Ok(text) = read_wayland_clipboard(paste::MimeType::Text) {
-            if let Ok(s) = String::from_utf8(text) {
-                last_text = s;
-            }
-        }
+		// Get initial clipboard state
+		if let Ok(types) = get_offered_mime_types() {
+			last_mime_types = {
+				let mut v: Vec<String> = types.into_iter().collect();
+				v.sort();
+				v
+			};
+		}
+		if let Ok(text) = read_wayland_clipboard(paste::MimeType::Text) {
+			if let Ok(s) = String::from_utf8(text) {
+				last_text = s;
+			}
+		}
 
-        loop {
-            if self
-                .stop_receiver
-                .recv_timeout(Duration::from_millis(500))
-                .is_ok()
-            {
-                break;
-            }
+		loop {
+			if self
+				.stop_receiver
+				.recv_timeout(Duration::from_millis(500))
+				.is_ok()
+			{
+				break;
+			}
 
-            let changed = if let Ok(bytes) = read_wayland_clipboard(paste::MimeType::Text) {
-                if let Ok(current) = String::from_utf8(bytes) {
-                    if current != last_text {
-                        last_text = current;
-                        true
-                    } else {
-                        false
-                    }
-                } else {
-                    false
-                }
-            } else {
-                // Clipboard might be empty or have non-text content
-                if !last_text.is_empty() {
-                    last_text.clear();
-                    true
-                } else {
-                    false
-                }
-            };
+			let changed = if let Ok(types) = get_offered_mime_types() {
+				let mut current_types: Vec<String> = types.into_iter().collect();
+				current_types.sort();
 
-            if changed {
-                self.handlers
-                    .iter_mut()
-                    .for_each(|handler| handler.on_clipboard_change());
-            }
-        }
-    }
+				if current_types != last_mime_types {
+					// MIME types changed, clipboard definitely changed
+					last_mime_types = current_types;
+					// Update text cache too
+					if let Ok(bytes) = read_wayland_clipboard(paste::MimeType::Text) {
+						if let Ok(s) = String::from_utf8(bytes) {
+							last_text = s;
+						}
+					} else {
+						last_text.clear();
+					}
+					true
+				} else if let Ok(bytes) = read_wayland_clipboard(paste::MimeType::Text) {
+					// Same MIME types, check if text content changed
+					if let Ok(current) = String::from_utf8(bytes) {
+						if current != last_text {
+							last_text = current;
+							true
+						} else {
+							false
+						}
+					} else {
+						false
+					}
+				} else if !last_text.is_empty() {
+					last_text.clear();
+					true
+				} else {
+					false
+				}
+			} else {
+				// No clipboard content available
+				if !last_mime_types.is_empty() {
+					last_mime_types.clear();
+					last_text.clear();
+					true
+				} else {
+					false
+				}
+			};
 
+			if changed {
+				self.handlers
+					.iter_mut()
+					.for_each(|handler| handler.on_clipboard_change());
+			}
+		}
+	}
 }
 
 // get_shutdown_channel is handled by the linux_clipboard wrapper in mod.rs
 
 pub struct WatcherShutdown {
-    pub(crate) sender: Sender<()>,
+	pub(crate) sender: Sender<()>,
 }
 
 impl Drop for WatcherShutdown {
-    fn drop(&mut self) {
-        let _ = self.sender.send(());
-    }
+	fn drop(&mut self) {
+		let _ = self.sender.send(());
+	}
 }

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -9,7 +9,7 @@ use crate::{
 #[cfg(feature = "image")]
 use crate::{common::RustImage, RustImageData};
 
-use crate::{Clipboard, ClipboardWatcher};
+use crate::Clipboard;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::{
 	sync::{Arc, RwLock},
@@ -707,8 +707,8 @@ impl Clipboard for ClipboardContext {
 }
 
 pub struct ClipboardWatcherContext<T: ClipboardHandler> {
-	handlers: Vec<T>,
-	stop_signal: Sender<()>,
+	pub(crate) handlers: Vec<T>,
+	pub(crate) stop_signal: Sender<()>,
 	stop_receiver: Receiver<()>,
 }
 
@@ -725,13 +725,8 @@ impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 	}
 }
 
-impl<T: ClipboardHandler> ClipboardWatcher<T> for ClipboardWatcherContext<T> {
-	fn add_handler(&mut self, f: T) -> &mut Self {
-		self.handlers.push(f);
-		self
-	}
-
-	fn start_watch(&mut self) {
+impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
+	pub(crate) fn start_watch_inner(&mut self) {
 		let watch_server = XServerContext::new().expect("Failed to create X server context");
 		let screen = watch_server
 			.conn
@@ -788,7 +783,7 @@ impl<T: ClipboardHandler> ClipboardWatcher<T> for ClipboardWatcherContext<T> {
 }
 
 pub struct WatcherShutdown {
-	sender: Sender<()>,
+	pub(crate) sender: Sender<()>,
 }
 
 impl Drop for WatcherShutdown {

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -775,7 +775,7 @@ impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 		}
 	}
 
-	fn get_shutdown_channel(&self) -> WatcherShutdown {
+	pub(crate) fn get_shutdown_channel(&self) -> WatcherShutdown {
 		WatcherShutdown {
 			sender: self.stop_signal.clone(),
 		}


### PR DESCRIPTION
Adds a Wayland backend alongside the existing X11 backend using `wl-clipboard-rs` (data-control protocol). Runtime detection via `WAYLAND_DISPLAY` env var with X11 fallback.

## How it works
- New optional `wayland` feature flag enables Wayland support
- Runtime detection: checks `WAYLAND_DISPLAY` env var
- If Wayland init fails, falls back to X11 automatically
- Uses `wl-clipboard-rs` for the data-control protocol (`ext-data-control-v1` / `wlr-data-control-unstable-v1`)

## Supported operations on Wayland
- Text via `text/plain` MIME type
- HTML via `text/html` MIME type
- RTF via `text/rtf` MIME type
- Images via `image/png` MIME type
- Files via `text/uri-list` MIME type
- Clipboard monitoring via polling (500ms interval)

## Usage
```toml
clipboard-rs = { version = "0.3", features = ["wayland"] }
```

No code changes needed for consumers. The existing `ClipboardContext::new()` automatically detects the session type.

## Compositor support
- GNOME (45+ supports `ext-data-control-v1`)
- KDE Plasma (5.27+)
- Hyprland
- Sway / wlroots compositors
- Any compositor implementing `wlr-data-control-unstable-v1`

## Motivation
This is needed for Flatpak/sandboxed apps running on Wayland where X11 is not available. Currently `ClipboardContext::new()` panics with `DisplayNotSet` on pure Wayland sessions.

Closes #2