### PR TITLE
chore: bump version to 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.3.3 (2026-02-24) [unreleased]
+## v0.3.4 (2026-04-02) [released]
 
 - Fix: Convert HTML to Windows CF_HTML format when setting multiple clipboard contents, fixing malformed HTML data in `set(Vec<ClipboardContent>)` on Windows [#80](https://github.com/ChurchTao/clipboard-rs/issues/80)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.3.4 (2026-04-02) [released]
 
 - Fix: Convert HTML to Windows CF_HTML format when setting multiple clipboard contents, fixing malformed HTML data in `set(Vec<ClipboardContent>)` on Windows [#80](https://github.com/ChurchTao/clipboard-rs/issues/80)
+- Merge pull request [#83](https://github.com/ChurchTao/clipboard-rs/pull/83) — feat: add Wayland clipboard support via wl-clipboard-rs
 
 ## v0.3.2 (2026-01-20) [released]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clipboard-rs"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["ChurchTao <swkzymlyy@gmail.com>"]
 description = "Cross-platform clipboard API (text | image | rich text | html | files | monitoring changes) | 跨平台剪贴板 API(文本|图片|富文本|html|文件|监听变化) Windows,MacOS,Linux"
 repository = "https://github.com/ChurchTao/clipboard-rs"


### PR DESCRIPTION
Bump version to v0.3.4.\n\nIncludes: PR #83 — feat: add Wayland clipboard support via wl-clipboard-rs\n\nRelease date: 2026-04-02\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>