### PR TITLE
feat: configurable watch interval + event-driven Windows watcher

### DIFF
--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -27,12 +27,26 @@ pub struct ClipboardWatcherContext<T: ClipboardHandler> {
 	stop_signal: Sender<()>,
 	stop_receiver: Receiver<()>,
 	running: bool,
+	interval: Duration,
 }
 
 unsafe impl<T: ClipboardHandler> Send for ClipboardWatcherContext<T> {}
 
+/// Default polling interval. macOS exposes no clipboard-change event, so the
+/// watcher polls `NSPasteboard.changeCount`; this is the wait between polls.
+const DEFAULT_WATCH_INTERVAL: Duration = Duration::from_millis(500);
+
 impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 	pub fn new() -> Result<Self> {
+		Self::new_with_interval(DEFAULT_WATCH_INTERVAL)
+	}
+
+	/// Creates a watcher that polls the pasteboard every `interval`.
+	///
+	/// macOS has no clipboard-change notification API, so changes are detected by
+	/// polling `changeCount`. A smaller `interval` lowers detection latency at the
+	/// cost of more frequent wake-ups; `new` uses [`DEFAULT_WATCH_INTERVAL`].
+	pub fn new_with_interval(interval: Duration) -> Result<Self> {
 		let ns_pasteboard = NSPasteboard::generalPasteboard();
 		let (tx, rx) = mpsc::channel();
 		Ok(ClipboardWatcherContext {
@@ -41,6 +55,7 @@ impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 			stop_signal: tx,
 			stop_receiver: rx,
 			running: false,
+			interval,
 		})
 	}
 }
@@ -64,11 +79,7 @@ impl<T: ClipboardHandler> ClipboardWatcher<T> for ClipboardWatcherContext<T> {
 		let mut last_change_count = self.pasteboard.changeCount();
 		loop {
 			// if receive stop signal, break loop
-			if self
-				.stop_receiver
-				.recv_timeout(Duration::from_millis(500))
-				.is_ok()
-			{
+			if self.stop_receiver.recv_timeout(self.interval).is_ok() {
 				break;
 			}
 			let change_count = self.pasteboard.changeCount();

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -188,6 +188,25 @@ mod linux_clipboard {
 			}
 			Ok(Self::X11(super::x11::ClipboardWatcherContext::new()?))
 		}
+
+		/// Creates a watcher with a custom poll `interval`, selecting the Wayland
+		/// or X11 backend the same way as [`Self::new`].
+		pub fn new_with_interval(interval: std::time::Duration) -> Result<Self> {
+			#[cfg(feature = "wayland")]
+			{
+				if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+					match super::wayland::ClipboardWatcherContext::new_with_interval(interval) {
+						Ok(ctx) => return Ok(Self::Wayland(ctx)),
+						Err(e) => {
+							eprintln!("Wayland watcher init failed, falling back to X11: {}", e);
+						}
+					}
+				}
+			}
+			Ok(Self::X11(
+				super::x11::ClipboardWatcherContext::new_with_interval(interval)?,
+			))
+		}
 	}
 
 	impl<T: ClipboardHandler + Send> crate::ClipboardWatcher<T> for ClipboardWatcherContext<T> {

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -308,12 +308,26 @@ pub struct ClipboardWatcherContext<T: ClipboardHandler> {
 	pub(crate) handlers: Vec<T>,
 	pub(crate) stop_signal: Sender<()>,
 	stop_receiver: Receiver<()>,
+	interval: Duration,
 }
 
 unsafe impl<T: ClipboardHandler + Send> Send for ClipboardWatcherContext<T> {}
 
+/// Default polling interval. The Wayland backend has no change-notification
+/// protocol, so it polls the clipboard; this is the wait between polls.
+const DEFAULT_WATCH_INTERVAL: Duration = Duration::from_millis(500);
+
 impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 	pub fn new() -> Result<Self> {
+		Self::new_with_interval(DEFAULT_WATCH_INTERVAL)
+	}
+
+	/// Creates a watcher that polls the clipboard every `interval`.
+	///
+	/// Wayland exposes no clipboard-change notification, so changes are detected
+	/// by polling. A smaller `interval` lowers detection latency at the cost of
+	/// more frequent wake-ups; `new` uses [`DEFAULT_WATCH_INTERVAL`].
+	pub fn new_with_interval(interval: Duration) -> Result<Self> {
 		// Verify data-control protocol is available (same check as ClipboardContext)
 		is_primary_selection_supported()
 			.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
@@ -322,6 +336,7 @@ impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 			handlers: Vec::new(),
 			stop_signal: tx,
 			stop_receiver: rx,
+			interval,
 		})
 	}
 }
@@ -352,11 +367,7 @@ impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 		}
 
 		loop {
-			if self
-				.stop_receiver
-				.recv_timeout(Duration::from_millis(500))
-				.is_ok()
-			{
+			if self.stop_receiver.recv_timeout(self.interval).is_ok() {
 				break;
 			}
 

--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::io::Cursor;
-use std::sync::mpsc::{Receiver, Sender};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use std::{mem, ptr, thread};
+use std::{mem, ptr};
 
 use crate::common::{ContentData, Result};
 #[cfg(feature = "image")]
@@ -26,7 +26,7 @@ use windows::Win32::Graphics::Gdi::{
 use windows::Win32::System::DataExchange::SetClipboardData;
 
 pub struct WatcherShutdown {
-	stop_signal: Sender<()>,
+	state: Arc<Mutex<ShutdownState>>,
 }
 
 static UNKNOWN_FORMAT: &str = "unknown format";
@@ -39,10 +39,26 @@ pub struct ClipboardContext {
 	html_format: formats::Html,
 }
 
+/// Shared shutdown state between a [`WatcherShutdown`] handle and the running
+/// watch loop.
+///
+/// The `clipboard_win` [`Monitor`] (and thus its `Shutdown`) must be created on
+/// the thread that runs `start_watch`, but `get_shutdown_channel` is typically
+/// called earlier on another thread. This state bridges that gap and is guarded
+/// by a mutex so the handoff is race-free: storing the live `Shutdown` and
+/// observing a pre-start stop request both happen under the same lock.
+enum ShutdownState {
+	/// Watch loop has not published its `Shutdown` yet.
+	NotStarted,
+	/// Watch loop is running; dropping this `Shutdown` interrupts `recv`.
+	Running(clipboard_win::monitor::Shutdown),
+	/// Stop was requested before the watch loop published its `Shutdown`.
+	StopRequested,
+}
+
 pub struct ClipboardWatcherContext<T: ClipboardHandler> {
 	handlers: Vec<T>,
-	stop_signal: Sender<()>,
-	stop_receiver: Receiver<()>,
+	state: Arc<Mutex<ShutdownState>>,
 	running: bool,
 }
 
@@ -90,13 +106,18 @@ impl ClipboardContext {
 
 impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 	pub fn new() -> Result<Self> {
-		let (tx, rx) = std::sync::mpsc::channel();
 		Ok(Self {
 			handlers: Vec::new(),
-			stop_signal: tx,
-			stop_receiver: rx,
+			state: Arc::new(Mutex::new(ShutdownState::NotStarted)),
 			running: false,
 		})
+	}
+
+	/// Creates a watcher. Provided for cross-platform API symmetry with the
+	/// macOS backend; `_interval` is ignored on Windows because changes are
+	/// delivered by the OS via `WM_CLIPBOARDUPDATE` rather than polled.
+	pub fn new_with_interval(_interval: Duration) -> Result<Self> {
+		Self::new()
 	}
 }
 
@@ -454,43 +475,60 @@ impl<T: ClipboardHandler> ClipboardWatcher<T> for ClipboardWatcherContext<T> {
 		}
 		self.running = true;
 		let mut monitor = Monitor::new().expect("create monitor error");
-		let shutdown = monitor.shutdown_channel();
-		loop {
-			if self.stop_receiver.try_recv().is_ok() {
-				break;
+
+		// Publish the live Shutdown so a WatcherShutdown can interrupt `recv`.
+		// If stop was already requested before we got here, bail out at once.
+		{
+			let mut state = self.state.lock().unwrap();
+			if matches!(*state, ShutdownState::StopRequested) {
+				self.running = false;
+				return;
 			}
-			let msg = monitor.try_recv();
-			match msg {
+			*state = ShutdownState::Running(monitor.shutdown_channel());
+		}
+
+		loop {
+			match monitor.recv() {
+				// New clipboard update.
 				Ok(true) => {
 					self.handlers.iter_mut().for_each(|f| {
 						f.on_clipboard_change();
 					});
 				}
-				Ok(false) => {
-					// no change
-					thread::park_timeout(Duration::from_millis(200));
-					continue;
-				}
+				// Shutdown requested (Shutdown handle dropped).
+				Ok(false) => break,
 				Err(e) => {
 					eprintln!("watch error, code = {e}");
 					break;
 				}
 			}
 		}
-		drop(shutdown);
+		*self.state.lock().unwrap() = ShutdownState::NotStarted;
 		self.running = false;
 	}
 
 	fn get_shutdown_channel(&self) -> WatcherShutdown {
 		WatcherShutdown {
-			stop_signal: self.stop_signal.clone(),
+			state: self.state.clone(),
 		}
 	}
 }
 
 impl Drop for WatcherShutdown {
 	fn drop(&mut self) {
-		let _ = self.stop_signal.send(());
+		// Take the current state, marking a stop request, then act on what we
+		// took after releasing the lock.
+		let taken = {
+			let mut state = self.state.lock().unwrap();
+			std::mem::replace(&mut *state, ShutdownState::StopRequested)
+		};
+		match taken {
+			// Loop is blocked in `recv`; dropping its Shutdown interrupts it.
+			ShutdownState::Running(shutdown) => drop(shutdown),
+			// Loop has not started (or already stopped): StopRequested, written
+			// above, makes it bail out before entering `recv`.
+			ShutdownState::NotStarted | ShutdownState::StopRequested => {}
+		}
 	}
 }
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -426,15 +426,12 @@ fn process_server_req(context: &InnerContext) -> Result<()> {
 					.handle_selection_request(event)
 					.map_err(|e| format!("handle_selection_request error: {e:?}"))?;
 			}
-			Event::SelectionNotify(event) => {
+			Event::SelectionNotify(event) if event.selection != atoms.CLIPBOARD_MANAGER => {
 				// We've requested the clipboard content and this is the answer.
 				// Considering that this thread is not responsible for reading
 				// clipboard contents, this must come from the clipboard manager
 				// signaling that the data was handed over successfully.
-				if event.selection != atoms.CLIPBOARD_MANAGER {
-					println!("Received a `SelectionNotify` from a selection other than the CLIPBOARD_MANAGER. This is unexpected in this thread.");
-					continue;
-				}
+				println!("Received a `SelectionNotify` from a selection other than the CLIPBOARD_MANAGER. This is unexpected in this thread.");
 			}
 			_event => {
 				// May be useful for debugging but nothing else really.

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -710,17 +710,33 @@ pub struct ClipboardWatcherContext<T: ClipboardHandler> {
 	pub(crate) handlers: Vec<T>,
 	pub(crate) stop_signal: Sender<()>,
 	stop_receiver: Receiver<()>,
+	interval: Duration,
 }
 
 unsafe impl<T: ClipboardHandler> Send for ClipboardWatcherContext<T> {}
 
+/// Default interval between checks for a stop signal. X11 delivers clipboard
+/// changes via XFixes events; this only bounds how quickly a stop request is
+/// observed, not change-detection latency.
+const DEFAULT_WATCH_INTERVAL: Duration = Duration::from_millis(500);
+
 impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 	pub fn new() -> Result<Self> {
+		Self::new_with_interval(DEFAULT_WATCH_INTERVAL)
+	}
+
+	/// Creates a watcher with a custom stop-signal poll `interval`.
+	///
+	/// Provided for cross-platform API symmetry; on X11 clipboard changes arrive
+	/// as XFixes events, so `interval` only affects how promptly a stop request
+	/// is noticed between event polls.
+	pub fn new_with_interval(interval: Duration) -> Result<Self> {
 		let (tx, rx) = mpsc::channel();
 		Ok(Self {
 			handlers: Vec::new(),
 			stop_signal: tx,
 			stop_receiver: rx,
+			interval,
 		})
 	}
 }
@@ -750,11 +766,7 @@ impl<T: ClipboardHandler> ClipboardWatcherContext<T> {
 		cookie.check().unwrap();
 
 		loop {
-			if self
-				.stop_receiver
-				.recv_timeout(Duration::from_millis(500))
-				.is_ok()
-			{
+			if self.stop_receiver.recv_timeout(self.interval).is_ok() {
 				break;
 			}
 			let event = match watch_server

--- a/tests/watch_test.rs
+++ b/tests/watch_test.rs
@@ -1,0 +1,64 @@
+use clipboard_rs::{
+	Clipboard, ClipboardContext, ClipboardHandler, ClipboardWatcher, ClipboardWatcherContext,
+};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+struct CountingHandler {
+	tx: mpsc::Sender<()>,
+}
+
+impl ClipboardHandler for CountingHandler {
+	fn on_clipboard_change(&mut self) {
+		// Ignore send errors: the receiver may already be gone on shutdown.
+		let _ = self.tx.send(());
+	}
+}
+
+// Watching touches the real system clipboard and needs a desktop session. CI
+// runs `cargo test --all` on the macOS/Windows desktop runners, where this (like
+// the other clipboard tests) executes normally.
+#[test]
+fn test_watch_with_short_interval_detects_change_and_shuts_down() {
+	let (tx, rx) = mpsc::channel();
+
+	// A short interval is the whole point of `new_with_interval`: detection
+	// latency on the polling backends should track it rather than the 500ms
+	// default. On event-driven backends the interval is accepted and ignored.
+	let mut watcher =
+		ClipboardWatcherContext::new_with_interval(Duration::from_millis(50)).unwrap();
+	let shutdown = watcher
+		.add_handler(CountingHandler { tx })
+		.get_shutdown_channel();
+
+	let watch_thread = thread::spawn(move || {
+		watcher.start_watch();
+	});
+
+	// Give the watcher a moment to record the initial change count, then mutate
+	// the clipboard so the handler fires.
+	thread::sleep(Duration::from_millis(200));
+	let ctx = ClipboardContext::new().unwrap();
+	ctx.set_text("clipboard-rs watch interval test".to_string())
+		.unwrap();
+
+	// The change should be observed well within a second given the 50ms poll.
+	rx.recv_timeout(Duration::from_secs(5))
+		.expect("watcher should observe the clipboard change");
+
+	// Shutting down must unblock `start_watch` so the thread can join.
+	shutdown.stop();
+	watch_thread.join().expect("watch thread should join");
+}
+
+// `new` must keep its original behavior and signature (back-compat).
+#[test]
+fn test_new_still_works_without_interval() {
+	let _watcher: ClipboardWatcherContext<NoopHandler> = ClipboardWatcherContext::new().unwrap();
+}
+
+struct NoopHandler;
+impl ClipboardHandler for NoopHandler {
+	fn on_clipboard_change(&mut self) {}
+}


### PR DESCRIPTION
## Motivation

The clipboard watcher had two latency issues:

1. **All polling backends (macOS / X11 / Wayland) hardcode a 500ms poll interval** with no way to configure it. There's no API to trade wake-up frequency for lower change-detection latency.
2. **The Windows backend degrades its own event-driven mechanism into a poll.** `clipboard-win`'s `Monitor` exposes a blocking `recv()` that wakes on `WM_CLIPBOARDUPDATE`, but `start_watch` used `try_recv()` + `park_timeout(200ms)`, adding up to 200ms of latency and a needless busy-wait.

## Changes

- **New `ClipboardWatcherContext::new_with_interval(Duration)`** on all backends (macOS, Windows, X11, Wayland, and the Linux dispatch wrapper). `new()` is unchanged and still defaults to 500ms, so this is fully backward compatible.
- **macOS / X11 / Wayland:** the polling loop now uses the configured interval instead of the hardcoded 500ms.
- **Windows:** replaced the `try_recv()` + `park_timeout(200ms)` busy-poll with the blocking `Monitor::recv()`, so the handler fires on the OS event with no added latency and no idle CPU. Shutdown now uses `clipboard-win`'s own `Shutdown` handle, bridged from the watch thread to the `WatcherShutdown` via a mutex-guarded state. This also handles the race where stop is requested before the watch loop starts. On Windows `new_with_interval` accepts the interval and ignores it (the backend is event-driven), kept for cross-platform API symmetry.

## Tests

Added `tests/watch_test.rs`:
- short-interval watcher detects a clipboard change and shuts down cleanly (thread joins);
- `new()` still compiles and works without an interval (back-compat).

## Verification

- **macOS:** `cargo fmt --check`, `cargo clippy --all -- -D warnings`, and `cargo test --test watch_test` all pass locally.
- **Windows:** `cargo clippy --all --target x86_64-pc-windows-msvc -- -D warnings` passes locally (cross-checked from macOS).
- **Linux (X11/Wayland):** changes are symmetric with the other polling backends but were **not** built locally (no Linux toolchain on hand); relying on this repo's ubuntu CI to verify.
