### PR TITLE
Bump version to 0.3.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clipboard-rs"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["ChurchTao <swkzymlyy@gmail.com>"]
 description = "Cross-platform clipboard API (text | image | rich text | html | files | monitoring changes) | 跨平台剪贴板 API(文本|图片|富文本|html|文件|监听变化) Windows,MacOS,Linux"
 repository = "https://github.com/ChurchTao/clipboard-rs"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add the following content to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-clipboard-rs = "0.3.3"
+clipboard-rs = "0.3.5"
 ```
 
 ## [CHANGELOG](CHANGELOG.md)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -37,7 +37,7 @@ clipboard-rs 是一个用 Rust 语言编写的跨平台库，用于获取和设�
 
 ```toml
 [dependencies]
-clipboard-rs = "0.3.3"
+clipboard-rs = "0.3.5"
 ```
 
 ## [更新日志](CHANGELOG.md)


### PR DESCRIPTION
Update Cargo.toml version to 0.3.5 and update README and README_ZH dependency examples from 0.3.3 to 0.3.5 to reflect the new release.